### PR TITLE
feat(evil): adjust the app name in the version info

### DIFF
--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -88,7 +88,7 @@ FLAGS:
     }
 
     if args.display_version {
-        println!("helix {}", VERSION_AND_GIT_HASH);
+        println!("evil-helix {}", VERSION_AND_GIT_HASH);
         std::process::exit(0);
     }
 


### PR DESCRIPTION
To make it easier for users to verify that they are indeed running the evil build of Helix (cf. #4), adjust the version info.

Until now, `hx --version` would print something like this:
```
helix 24.3 (19e375d8)
```

With this PR, the output is changed as follows:
```
evil-helix 24.3 (19e375d8)
```