### PR TITLE
fix(evil): ensure evil mode is enabled by default

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -29,8 +29,8 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             theme: None,
-            keys: keymap::default(),
-            editor: helix_view::editor::Config::default(),
+            keys: keymap::default_evil(),
+            editor: helix_view::editor::Config::default_evil(),
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -877,7 +877,7 @@ pub enum PopupBorderConfig {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            evil: true,
+            evil: false,
             scrolloff: 5,
             scroll_lines: 3,
             mouse: true,
@@ -927,6 +927,15 @@ impl Default for Config {
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
         }
+    }
+}
+
+impl Config {
+    pub fn default_evil() -> Self {
+        let mut config = Config::default();
+        config.evil = true;
+        config.statusline.mode = ModeConfig::default_evil();
+        return config;
     }
 }
 


### PR DESCRIPTION
When starting without a user configuration, the editor would load with `evil` set to `false`. Fix this by not only adjusting the defaults, but by separating the defaults in respective `default_evil()` functions. The editor is now evil by default.

Fixes #4