### PR TITLE
feat(defaults): statusline layout & colors and make `insert_final_newline` opt-in

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -82,7 +82,7 @@ impl Config {
                 }
 
                 let editor = match (global.editor, local.editor) {
-                    (None, None) => helix_view::editor::Config::default(),
+                    (None, None) => helix_view::editor::Config::default_evil(),
                     (None, Some(val)) | (Some(val), None) => {
                         val.try_into().map_err(ConfigLoadError::BadConfig)?
                     }
@@ -116,7 +116,7 @@ impl Config {
                     theme: config.theme,
                     keys,
                     editor: config.editor.map_or_else(
-                        || Ok(helix_view::editor::Config::default()),
+                        || Ok(helix_view::editor::Config::default_evil()),
                         |val| val.try_into().map_err(ConfigLoadError::BadConfig),
                     )?,
                 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -970,6 +970,7 @@ impl Config {
         config.evil = true;
         config.statusline = StatusLineConfig::default_evil();
         config.color_modes = true;
+        config.insert_final_newline = false;
         config.smart_tab = Some(SmartTabConfig::default_evil());
         return config;
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -350,6 +350,15 @@ pub struct SmartTabConfig {
 impl Default for SmartTabConfig {
     fn default() -> Self {
         SmartTabConfig {
+            enable: true,
+            supersede_menu: false,
+        }
+    }
+}
+
+impl SmartTabConfig {
+    pub fn default_evil() -> Self {
+        SmartTabConfig {
             enable: false,
             supersede_menu: false,
         }
@@ -961,6 +970,7 @@ impl Config {
         config.evil = true;
         config.statusline = StatusLineConfig::default_evil();
         config.color_modes = true;
+        config.smart_tab = Some(SmartTabConfig::default_evil());
         return config;
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -487,6 +487,31 @@ impl Default for StatusLineConfig {
     }
 }
 
+impl StatusLineConfig {
+    pub fn default_evil() -> Self {
+        use StatusLineElement as E;
+
+        Self {
+            left: vec![E::Mode, E::Spacer, E::VersionControl, E::Spacer, E::Spinner],
+            center: vec![
+                E::FileName,
+                E::ReadOnlyIndicator,
+                E::FileModificationIndicator,
+            ],
+            right: vec![
+                E::Diagnostics,
+                E::Selections,
+                E::Register,
+                E::Position,
+                E::FileEncoding,
+                E::FileType,
+            ],
+            separator: String::from("│"),
+            mode: ModeConfig::default_evil(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct ModeConfig {
@@ -934,7 +959,8 @@ impl Config {
     pub fn default_evil() -> Self {
         let mut config = Config::default();
         config.evil = true;
-        config.statusline.mode = ModeConfig::default_evil();
+        config.statusline = StatusLineConfig::default_evil();
+        config.color_modes = true;
         return config;
     }
 }


### PR DESCRIPTION
The statusline is defaults are changed to bring a healthy balance between clarity (centered file path) and a lualine-like behavior (colored file-type, colors enabled by default).

The colors can still be deactivated by setting `editor.color-modes` to `false`.

Furthermode, `editor.insert_final_newline` is arguably unexpected behavior and is now an opt-in setting, i.e. disabled by default.