### PR TITLE
feat(evil): implement the long word motions (`W`, `B`, `E`)

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -522,6 +522,9 @@ impl MappableCommand {
         evil_prev_word_start, "Previous word start (evil)",
         evil_next_word_start, "Next word start (evil)",
         evil_next_word_end, "Next word end (evil)",
+        evil_prev_long_word_start, "Previous long word start (evil)",
+        evil_next_long_word_start, "Next long word start (evil)",
+        evil_next_long_word_end, "Next long word end (evil)",
         evil_delete, "Delete (evil)",
         evil_delete_immediate, "Delete immediately (evil)",
         evil_yank, "Yank (evil)",
@@ -6268,6 +6271,21 @@ fn evil_next_word_start(cx: &mut Context) {
 fn evil_next_word_end(cx: &mut Context) {
     // TODO: evil-specific implementation in evil.rs
     evil_move_word_impl(cx, movement::move_next_word_end);
+}
+
+fn evil_prev_long_word_start(cx: &mut Context) {
+    // TODO: evil-specific implementation in evil.rs
+    evil_move_word_impl(cx, movement::move_prev_long_word_start);
+}
+
+fn evil_next_long_word_start(cx: &mut Context) {
+    // TODO: evil-specific implementation in evil.rs
+    evil_move_word_impl(cx, movement::move_next_long_word_start);
+}
+
+fn evil_next_long_word_end(cx: &mut Context) {
+    // TODO: evil-specific implementation in evil.rs
+    evil_move_word_impl(cx, movement::move_next_long_word_end);
 }
 
 fn evil_delete(cx: &mut Context) {

--- a/helix-term/src/commands/evil.rs
+++ b/helix-term/src/commands/evil.rs
@@ -54,6 +54,8 @@ impl TryFrom<char> for Modifier {
 enum Motion {
     PrevWordStart,
     NextWordEnd,
+    PrevLongWordStart,
+    NextLongWordEnd,
     LineStart,
     LineEnd,
 }
@@ -202,6 +204,16 @@ impl EvilCommands {
                             Self::get_bidirectional_word_based_selection(cx).ok()
                         }
                         Motion::PrevWordStart | Motion::NextWordEnd => {
+                            Self::get_word_based_selection(cx, motion).ok()
+                        }
+                        Motion::PrevLongWordStart | Motion::NextLongWordEnd
+                            if has_inner_word_modifier =>
+                        {
+                            // TODO: this doesn't support long words yet
+                            Self::get_bidirectional_word_based_selection(cx).ok()
+                        }
+                        Motion::PrevLongWordStart | Motion::NextLongWordEnd => {
+                            // TODO: this doesn't support long words yet
                             Self::get_word_based_selection(cx, motion).ok()
                         }
                         Motion::LineStart | Motion::LineEnd => {

--- a/helix-term/src/commands/evil.rs
+++ b/helix-term/src/commands/evil.rs
@@ -65,8 +65,10 @@ impl TryFrom<char> for Motion {
 
     fn try_from(value: char) -> Result<Self, Self::Error> {
         match value {
-            'w' => Ok(Self::NextWordEnd),
+            'w' | 'e' => Ok(Self::NextWordEnd),
             'b' => Ok(Self::PrevWordStart),
+            'W' | 'E' => Ok(Self::NextLongWordEnd),
+            'B' => Ok(Self::PrevLongWordStart),
             '$' => Ok(Self::LineEnd),
             '0' => Ok(Self::LineStart),
             _ => Err(()),

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -738,9 +738,9 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         "b" => evil_prev_word_start,
         "e" => evil_next_word_end,
         "w" => evil_next_word_start,
-        // TODO: "B" => evil_prev_long_word_start,
-        // TODO: "E" => evil_next_long_word_end,
-        // TODO: "W" => evil_next_long_word_start,
+        "B" => evil_prev_long_word_start,
+        "E" => evil_next_long_word_end,
+        "W" => evil_next_long_word_start,
 
         "0" => goto_line_start,
         "$" => goto_line_end,


### PR DESCRIPTION
This adds support for moving over long words.

**Known issue**: Using these motions as part of commands is also supported, but when used as such, the motions will still be treated as regular word motions.