### PR TITLE
chore(evil): clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ These are the current differences compared to the upstream project:
 -	If `color_modes` is enabled, color the file type in the statusline as well ([5503542](https://github.com/usagi-flow/evil-helix/commit/5503542c0314936ea91464f2944666ed42fea86c))
 -	Minimalistic window separator ([dd990ca](https://github.com/usagi-flow/evil-helix/commit/dd990cad1cb92a024321aca19728c68cb066dd09))
 
+Moreover, evil-helix introduces the `editor.evil` option, which is `true` by default. It can be set to false to completely deactivate evil-helix behavior without having to use a different build:
+
+```toml
+[editor]
+evil = true # Default; set this to `false` to disable evil-helix behavior
+```
+
 ## Project philosophy
 
 ### Configurable features instead of plugins

--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ Considering the kind and frequency of changes to this repository, it makes sense
 
 ## Development
 
-Keep in mind the `main` branch is regularly being rebased onto the upstream `master` branch.
+Keep in mind the `main` branch may be rebased onto the upstream `master` branch.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ These are the current differences compared to the upstream project:
 -	Basic Vim modeline support ([#3](https://github.com/usagi-flow/evil-helix/pull/3))
 -	Adjusted defaults ([511060a](https://github.com/usagi-flow/evil-helix/commit/511060abcfcbe9377ec50e8a0ecaf4c0660776bb)):
 	-	The Helix "SEL" mode is called "VIS"
-	-	The default theme is `catppuccin_macchiato`
 	-	Smart tab is disabled by default
 -	If `color_modes` is enabled, color the file type in the statusline as well ([5503542](https://github.com/usagi-flow/evil-helix/commit/5503542c0314936ea91464f2944666ed42fea86c))
 -	Minimalistic window separator ([dd990ca](https://github.com/usagi-flow/evil-helix/commit/dd990cad1cb92a024321aca19728c68cb066dd09))

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -187,7 +187,7 @@ impl Config {
                 .expect("Incorrect type for `editor.config`, expected `bool`");
         }
 
-        log::info!("Evil mode not set in local/global config");
+        log::debug!("Evil mode not explicitly set in local/global config, will enable default");
         return true;
     }
 


### PR DESCRIPTION
**Logging**:
- improve logging to avoid misconceptions

**README.md**:
- remove the mention of a different default theme (it doesn't work well yet)
- we don't rebase that often anymore (but we still might do so in the future)
- document the `editor.evil` option

Related to #8 and #40.