### PR TITLE
Make `w`, `W`, `e`, `E`, `b` and `B` in normal and select mode behave exactly like Vim

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -213,7 +213,7 @@ pub fn move_prev_sub_word_end(slice: RopeSlice, range: Range, count: usize) -> R
     word_move(slice, range, count, WordMotionTarget::PrevSubWordEnd)
 }
 
-fn word_move(slice: RopeSlice, range: Range, count: usize, target: WordMotionTarget) -> Range {
+pub fn word_move(slice: RopeSlice, range: Range, count: usize, target: WordMotionTarget) -> Range {
     let is_prev = matches!(
         target,
         WordMotionTarget::PrevWordStart
@@ -407,6 +407,9 @@ pub enum WordMotionTarget {
     NextSubWordEnd,
     PrevSubWordStart,
     PrevSubWordEnd,
+    // Evil
+    EvilNextWordStart,
+    EvilNextLongWordStart,
 }
 
 pub trait CharHelpers {
@@ -554,6 +557,14 @@ fn reached_target(target: WordMotionTarget, prev_ch: char, next_ch: char) -> boo
         WordMotionTarget::PrevSubWordStart => {
             is_sub_word_boundary(prev_ch, next_ch, Direction::Backward)
                 && (!(prev_ch.is_whitespace() || prev_ch == '_') || char_is_line_ending(next_ch))
+        }
+        WordMotionTarget::EvilNextWordStart => {
+            is_word_boundary(prev_ch, next_ch)
+                && (!char_is_line_ending(next_ch) && !next_ch.is_whitespace())
+        }
+        WordMotionTarget::EvilNextLongWordStart => {
+            is_long_word_boundary(prev_ch, next_ch)
+                && (!char_is_line_ending(next_ch) && !next_ch.is_whitespace())
         }
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6563,29 +6563,14 @@ fn evil_move_word_impl<F>(cx: &mut Context, move_fn: F)
 where
     F: Fn(RopeSlice, Range, usize) -> Range,
 {
-    let count = cx.count();
-    let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-
-    let selection = doc.selection(view.id).clone().transform(|range| {
-        let old_head = range.head;
-        let old_anchor = range.anchor;
-        let mut new_range = move_fn(text, range, count);
-
-        new_range.anchor = match cx.editor.mode {
-            // In select mode, use a sticky anchor and move the head only;
-            // keeping in mind that in select mode, with a single char selected,
-            // the anchor typically points *before* the character.
-            Mode::Select if new_range.head < old_head => old_head.max(old_anchor),
-            Mode::Select => old_head.min(old_anchor),
+    match cx.editor.mode {
+        Mode::Select => extend_word_impl(cx, move_fn),
+        _ => {
             // When not in select mode, just move the cursor and do not select
-            _ => new_range.head,
-        };
-
-        return new_range;
-    });
-
-    doc.set_selection(view.id, selection);
+            move_word_impl(cx, move_fn);
+            collapse_selection(cx)
+        }
+    }
 }
 
 fn evil_prev_word_start(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6580,9 +6580,7 @@ fn evil_prev_word_start(cx: &mut Context) {
 }
 
 fn evil_next_word_start(cx: &mut Context) {
-    // TODO: evil-specific implementation in evil.rs
-    evil_move_word_impl(cx, movement::move_next_word_start);
-    //EvilCommands::next_word_start(cx);
+    evil_move_word_impl(cx, EvilCommands::move_next_word_start);
 }
 
 fn evil_next_word_end(cx: &mut Context) {
@@ -6596,8 +6594,7 @@ fn evil_prev_long_word_start(cx: &mut Context) {
 }
 
 fn evil_next_long_word_start(cx: &mut Context) {
-    // TODO: evil-specific implementation in evil.rs
-    evil_move_word_impl(cx, movement::move_next_long_word_start);
+    evil_move_word_impl(cx, EvilCommands::move_next_long_word_start);
 }
 
 fn evil_next_long_word_end(cx: &mut Context) {

--- a/helix-term/src/commands/evil.rs
+++ b/helix-term/src/commands/evil.rs
@@ -5,6 +5,11 @@ use std::{
 
 use helix_core::movement::move_prev_word_start;
 use helix_core::movement::{is_word_boundary, Direction};
+use helix_core::movement::{
+    move_horizontally, word_move, Movement,
+    WordMotionTarget::{EvilNextLongWordStart, EvilNextWordStart},
+};
+use helix_core::{doc_formatter::TextFormat, text_annotations::TextAnnotations, RopeSlice};
 use helix_core::{movement::move_next_word_end, Rope};
 use helix_core::{Range, Selection, Transaction};
 use helix_view::document::Mode;
@@ -709,4 +714,28 @@ impl EvilCommands {
             log::warn!("The find_char base function did not set a key callback");
         }
     }
+
+    pub fn move_next_word_start(slice: RopeSlice, range: Range, count: usize) -> Range {
+        let range1 = move_one_char(slice, range, Direction::Backward);
+        let range2 = word_move(slice, range1, count, EvilNextWordStart);
+        move_one_char(slice, range2, Direction::Forward)
+    }
+
+    pub fn move_next_long_word_start(slice: RopeSlice, range: Range, count: usize) -> Range {
+        let range1 = move_one_char(slice, range, Direction::Backward);
+        let range2 = word_move(slice, range1, count, EvilNextLongWordStart);
+        move_one_char(slice, range2, Direction::Forward)
+    }
+}
+
+fn move_one_char(slice: RopeSlice, range: Range, direction: Direction) -> Range {
+    move_horizontally(
+        slice,
+        range,
+        direction,
+        1,
+        Movement::Move,
+        &TextFormat::default(),          // Not used
+        &mut TextAnnotations::default(), // Not used
+    )
 }


### PR DESCRIPTION
This pull request fixes the following bugs:

Commit 1:
* In select mode, the key sequence `wb` would result in a selection,
   instead of being a no-op as in Vim.

* The functions `evil_next_word_end` and `evil_next_long_word_end`
   (mapped to 'e' and 'E') in normal mode would make the cursor land on
   the space after the word, instead of the last character of the word.


Commit 2:
* Space before word: when the cursor is on the space before a word, and
   you hit `w`, Vim will move the cursor to this word, but evil-helix
   would skip the word and move to the _next_ word.

* Punctuation: when the cursor is on the letter 'f' in "foo.bar qux",
   and you hit `w` twice, Vim will move the cursor to the letter 'b',
   but evil-helix would skip to the letter 'q'.

   This bug has the same underlying cause as the previous one, and the
   fix for both is to move the cursor one character to the left before
   doing the word move.

* Newlines: when the cursor is on the 'f' in "foo\nbar", and you hit
   `w`, Vim will move the cursor to the letter 'b' (so to the next
   line), but evil-helix would move the cursor onto the newline
   character. See the changes in `reached_target` for the fix.

With this pull request, evil-helix passes all the tests defined here: https://github.com/thomie/vim-keymap-test/blob/a50b737fa75f44af84378f4e2d59be4da67bdd7b/word-motions.test. 

Closes https://github.com/usagi-flow/evil-helix/issues/44