### PR TITLE
Fix default evil editor config

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs;
 use std::io::Error as IOError;
+use std::path::PathBuf;
 use toml::de::Error as TomlError;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -22,6 +23,19 @@ pub struct ConfigRaw {
     pub theme: Option<String>,
     pub keys: Option<HashMap<Mode, KeyTrie>>,
     pub editor: Option<toml::Value>,
+}
+
+impl ConfigRaw {
+    pub fn load(path: PathBuf) -> Result<Option<ConfigRaw>, ConfigLoadError> {
+        match fs::read_to_string(path) {
+            // Don't treat a missing config file as an error.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(ConfigLoadError::Error(e)),
+            Ok(s) => toml::from_str(&s)
+                .map(Some)
+                .map_err(ConfigLoadError::BadConfig),
+        }
+    }
 }
 
 impl Default for Config {
@@ -56,80 +70,40 @@ impl Display for ConfigLoadError {
 }
 
 impl Config {
-    pub fn load(
-        global: Result<String, ConfigLoadError>,
-        local: Result<String, ConfigLoadError>,
-    ) -> Result<Config, ConfigLoadError> {
-        let global_config: Result<ConfigRaw, ConfigLoadError> =
-            global.and_then(|file| toml::from_str(&file).map_err(ConfigLoadError::BadConfig));
-        let local_config: Result<ConfigRaw, ConfigLoadError> =
-            local.and_then(|file| toml::from_str(&file).map_err(ConfigLoadError::BadConfig));
-        let res = match (global_config, local_config) {
-            (Ok(global), Ok(local)) => {
-                let mut keys = keymap::default();
-                if let Some(global_keys) = global.keys {
-                    merge_keys(&mut keys, global_keys)
-                }
-                if let Some(local_keys) = local.keys {
-                    merge_keys(&mut keys, local_keys)
-                }
-
-                let editor = match (global.editor, local.editor) {
-                    (None, None) => helix_view::editor::Config::default(),
-                    (None, Some(val)) | (Some(val), None) => {
-                        val.try_into().map_err(ConfigLoadError::BadConfig)?
-                    }
-                    (Some(global), Some(local)) => merge_toml_values_with_strategy(
-                        global,
-                        local,
-                        &MergeStrategy {
-                            array: MergeMode::Never,
-                            table: MergeMode::Always,
-                        },
-                    )
-                    .try_into()
-                    .map_err(ConfigLoadError::BadConfig)?,
-                };
-
-                Config {
-                    theme: local.theme.or(global.theme),
-                    keys,
+    /// Merge a ConfigRaw value into a Config.
+    pub fn apply(&mut self, opt_config_raw: Option<ConfigRaw>) -> Result<(), ConfigLoadError> {
+        if let Some(config_raw) = opt_config_raw {
+            if let Some(theme) = config_raw.theme {
+                self.theme = Some(theme)
+            }
+            if let Some(keymap) = config_raw.keys {
+                merge_keys(&mut self.keys, keymap)
+            }
+            if let Some(editor) = config_raw.editor {
+                // We only know how to merge toml values, so convert back to toml first.
+                let val = toml::Value::try_from(&self.editor).unwrap();
+                self.editor = merge_toml_values_with_strategy(
+                    val,
                     editor,
-                }
+                    &MergeStrategy {
+                        array: MergeMode::Never,
+                        table: MergeMode::Always,
+                    },
+                )
+                .try_into()
+                .map_err(ConfigLoadError::BadConfig)?
             }
-            // if any configs are invalid return that first
-            (_, Err(ConfigLoadError::BadConfig(err)))
-            | (Err(ConfigLoadError::BadConfig(err)), _) => {
-                return Err(ConfigLoadError::BadConfig(err))
-            }
-            (Ok(config), Err(_)) | (Err(_), Ok(config)) => {
-                let mut keys = keymap::default();
-                if let Some(keymap) = config.keys {
-                    merge_keys(&mut keys, keymap);
-                }
-                Config {
-                    theme: config.theme,
-                    keys,
-                    editor: config.editor.map_or_else(
-                        || Ok(helix_view::editor::Config::default()),
-                        |val| val.try_into().map_err(ConfigLoadError::BadConfig),
-                    )?,
-                }
-            }
-
-            // these are just two io errors return the one for the global config
-            (Err(err), Err(_)) => return Err(err),
-        };
-
-        Ok(res)
+        }
+        Ok(())
     }
 
     pub fn load_default() -> Result<Config, ConfigLoadError> {
-        let global_config =
-            fs::read_to_string(helix_loader::config_file()).map_err(ConfigLoadError::Error);
-        let local_config = fs::read_to_string(helix_loader::workspace_config_file())
-            .map_err(ConfigLoadError::Error);
-        Config::load(global_config, local_config)
+        let mut config = Config::default();
+        let global = ConfigRaw::load(helix_loader::config_file())?;
+        let local = ConfigRaw::load(helix_loader::workspace_config_file())?;
+        config.apply(global)?;
+        config.apply(local)?;
+        Ok(config)
     }
 }
 
@@ -139,7 +113,12 @@ mod tests {
 
     impl Config {
         fn load_test(global: &str, local: &str) -> Config {
-            Config::load(Ok(global.to_owned()), Ok(local.to_owned())).unwrap()
+            let mut config = Config::default();
+            let global = Some(toml::from_str(&global).unwrap());
+            let local = Some(toml::from_str(&local).unwrap());
+            config.apply(global).unwrap();
+            config.apply(local).unwrap();
+            config
         }
     }
 
@@ -172,6 +151,13 @@ mod tests {
         "#;
         let config = Config::load_test(global, local);
         assert_eq!(config.editor.shell, ["fish", "-c"]);
+    }
+
+    #[test]
+    fn load_non_existing_config() {
+        let path = PathBuf::from(r"does-not-exist");
+        let result = ConfigRaw::load(path);
+        assert!(result.is_ok_and(|x| x.is_none()));
     }
 
     #[test]

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -2,7 +2,6 @@ use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
 use helix_loader::merge_toml_values;
 use helix_view::document::Mode;
-use helix_view::editor::ModeConfig;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -29,8 +28,8 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             theme: None,
-            keys: keymap::default_evil(),
-            editor: helix_view::editor::Config::default_evil(),
+            keys: keymap::default(),
+            editor: helix_view::editor::Config::default(),
         }
     }
 }
@@ -65,15 +64,9 @@ impl Config {
             global.and_then(|file| toml::from_str(&file).map_err(ConfigLoadError::BadConfig));
         let local_config: Result<ConfigRaw, ConfigLoadError> =
             local.and_then(|file| toml::from_str(&file).map_err(ConfigLoadError::BadConfig));
-        let evil = Self::is_evil(&global_config, &local_config);
-        let mut res = match (global_config, local_config) {
+        let res = match (global_config, local_config) {
             (Ok(global), Ok(local)) => {
-                let mut keys = if !evil {
-                    keymap::default()
-                } else {
-                    keymap::default_evil()
-                };
-
+                let mut keys = keymap::default();
                 if let Some(global_keys) = global.keys {
                     merge_keys(&mut keys, global_keys)
                 }
@@ -82,7 +75,7 @@ impl Config {
                 }
 
                 let editor = match (global.editor, local.editor) {
-                    (None, None) => helix_view::editor::Config::default_evil(),
+                    (None, None) => helix_view::editor::Config::default(),
                     (None, Some(val)) | (Some(val), None) => {
                         val.try_into().map_err(ConfigLoadError::BadConfig)?
                     }
@@ -103,12 +96,7 @@ impl Config {
                 return Err(ConfigLoadError::BadConfig(err))
             }
             (Ok(config), Err(_)) | (Err(_), Ok(config)) => {
-                let mut keys = if !evil {
-                    keymap::default()
-                } else {
-                    keymap::default_evil()
-                };
-
+                let mut keys = keymap::default();
                 if let Some(keymap) = config.keys {
                     merge_keys(&mut keys, keymap);
                 }
@@ -116,7 +104,7 @@ impl Config {
                     theme: config.theme,
                     keys,
                     editor: config.editor.map_or_else(
-                        || Ok(helix_view::editor::Config::default_evil()),
+                        || Ok(helix_view::editor::Config::default()),
                         |val| val.try_into().map_err(ConfigLoadError::BadConfig),
                     )?,
                 }
@@ -126,69 +114,7 @@ impl Config {
             (Err(err), Err(_)) => return Err(err),
         };
 
-        // HACK: because we can't easily differentiate between "no configuration" and
-        // "explicit non-evil mode configuration"
-        if evil {
-            res.editor.statusline.mode = ModeConfig::default_evil();
-        }
-
         Ok(res)
-    }
-
-    fn is_evil(
-        global_config: &Result<ConfigRaw, ConfigLoadError>,
-        local_config: &Result<ConfigRaw, ConfigLoadError>,
-    ) -> bool {
-        if local_config.is_ok()
-            && local_config.as_ref().unwrap().editor.is_some()
-            && local_config
-                .as_ref()
-                .unwrap()
-                .editor
-                .as_ref()
-                .unwrap()
-                .get("evil")
-                .is_some()
-        {
-            log::info!("Retrieving evil mode from local config");
-            return local_config
-                .as_ref()
-                .unwrap()
-                .editor
-                .as_ref()
-                .unwrap()
-                .get("evil")
-                .unwrap()
-                .as_bool()
-                .expect("Incorrect type for `editor.config`, expected `bool`");
-        }
-
-        if global_config.is_ok()
-            && global_config.as_ref().unwrap().editor.is_some()
-            && global_config
-                .as_ref()
-                .unwrap()
-                .editor
-                .as_ref()
-                .unwrap()
-                .get("evil")
-                .is_some()
-        {
-            log::info!("Retrieving evil mode from global config");
-            return global_config
-                .as_ref()
-                .unwrap()
-                .editor
-                .as_ref()
-                .unwrap()
-                .get("evil")
-                .unwrap()
-                .as_bool()
-                .expect("Incorrect type for `editor.config`, expected `bool`");
-        }
-
-        log::debug!("Evil mode not explicitly set in local/global config, will enable default");
-        return true;
     }
 
     pub fn load_default() -> Result<Config, ConfigLoadError> {
@@ -225,7 +151,7 @@ mod tests {
             A-F12 = "move_next_word_end"
         "#;
 
-        let mut keys = keymap::default_evil();
+        let mut keys = keymap::default();
         merge_keys(
             &mut keys,
             hashmap! {
@@ -252,10 +178,10 @@ mod tests {
     fn keys_resolve_to_correct_defaults() {
         // From serde default
         let default_keys = Config::load_test("").keys;
-        assert_eq!(default_keys, keymap::default_evil());
+        assert_eq!(default_keys, keymap::default());
 
         // From the Default trait
         let default_keys = Config::default().keys;
-        assert_eq!(default_keys, keymap::default_evil());
+        assert_eq!(default_keys, keymap::default());
     }
 }

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -42,6 +42,16 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             theme: None,
+            keys: keymap::default_evil(),
+            editor: helix_view::editor::Config::default_evil(),
+        }
+    }
+}
+
+impl Config {
+    pub fn default_helix() -> Config {
+        Config {
+            theme: None,
             keys: keymap::default(),
             editor: helix_view::editor::Config::default(),
         }
@@ -101,8 +111,14 @@ impl Config {
         let mut config = Config::default();
         let global = ConfigRaw::load(helix_loader::config_file())?;
         let local = ConfigRaw::load(helix_loader::workspace_config_file())?;
-        config.apply(global)?;
-        config.apply(local)?;
+        config.apply(global.clone())?;
+        config.apply(local.clone())?;
+        if !config.editor.evil {
+            // Deactivate evil-helix behavior.
+            config = Config::default_helix();
+            config.apply(global)?;
+            config.apply(local)?;
+        }
         Ok(config)
     }
 }
@@ -175,7 +191,7 @@ mod tests {
             A-F12 = "move_next_word_end"
         "#;
 
-        let mut keys = keymap::default();
+        let mut keys = keymap::default_evil();
         merge_keys(
             &mut keys,
             hashmap! {
@@ -202,10 +218,10 @@ mod tests {
     fn keys_resolve_to_correct_defaults() {
         // From serde default
         let default_keys = Config::load_test("", "").keys;
-        assert_eq!(default_keys, keymap::default());
+        assert_eq!(default_keys, keymap::default_evil());
 
         // From the Default trait
         let default_keys = Config::default().keys;
-        assert_eq!(default_keys, keymap::default());
+        assert_eq!(default_keys, keymap::default_evil());
     }
 }


### PR DESCRIPTION
This may look like a lot of changes, but everything except the [last commit](5fd50da499942b5c719a5e3ef7832ddb42231e82) (which is tiny) should go into helix upstream.

With theses change, all the `default_evil` editor settings apply even when the config file contains an editor section (#70).

And `statusline.mode` can be overridden from the config file (#53) (fixed by removing the "HACK" from config.rs).

Closes #53 ~(once #70 is merged as well)~ and #73.