### PR TITLE
feat: colored/rainbow indentation guides

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -304,11 +304,12 @@ tabpad = "·" # Tabs will look like "→···" (depending on tab width)
 
 Options for rendering vertical indent guides.
 
-| Key           | Description                                             | Default |
-| ---           | ---                                                     | ---     |
-| `render`      | Whether to render indent guides                         | `false` |
-| `character`   | Literal character to use for rendering the indent guide | `│`     |
-| `skip-levels` | Number of indent levels to skip                         | `0`     |
+| Key              | Description                                                           | Default |
+| ---              | ---                                                                   | ---     |
+| `render`         | Whether to render indent guides                                       | `false` |
+| `character`      | Literal character to use for rendering the indent guide               | `│`     |
+| `skip-levels`    | Number of indent levels to skip                                       | `0`     |
+| `rainbow-option` | Enum to set rainbow indentations. Options: `normal`, `dim` and `none` | `none`  |
 
 Example:
 
@@ -317,6 +318,7 @@ Example:
 render = true
 character = "╎" # Some characters that work well: "▏", "┆", "┊", "⸽"
 skip-levels = 1
+rainbow-option = "normal"
 ```
 
 ### `[editor.gutters]` Section

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -130,6 +130,17 @@ inherits = "boo_berry"
 berry = "#2A2A4D"
 ```
 
+### Rainbow
+
+The `rainbow` key is used for rainbow highlight for matching brackets.
+The key is a list of styles.
+
+```toml
+rainbow = ["#ff0000", "#ffa500", "#fff000", { fg = "#00ff00", modifiers = ["bold"] }]
+```
+
+Colors from the palette and modifiers may be used.
+
 ### Scopes
 
 The following is a list of scopes available to use for styling:

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -8,9 +8,9 @@ use helix_core::syntax::HighlightEvent;
 use helix_core::text_annotations::TextAnnotations;
 use helix_core::{visual_offset_from_block, Position, RopeSlice};
 use helix_stdx::rope::RopeSliceExt;
-use helix_view::editor::{WhitespaceConfig, WhitespaceRenderValue};
+use helix_view::editor::{RainbowIndentOptions, WhitespaceConfig, WhitespaceRenderValue};
 use helix_view::graphics::Rect;
-use helix_view::theme::Style;
+use helix_view::theme::{Modifier, Style};
 use helix_view::view::ViewPosition;
 use helix_view::{Document, Theme};
 use tui::buffer::Buffer as Surface;
@@ -256,6 +256,8 @@ pub struct TextRenderer<'a> {
     pub whitespace_style: Style,
     pub indent_guide_char: String,
     pub indent_guide_style: Style,
+    pub indent_guide_rainbow: RainbowIndentOptions,
+    pub theme: &'a Theme,
     pub newline: String,
     pub nbsp: String,
     pub nnbsp: String,
@@ -278,7 +280,7 @@ impl<'a> TextRenderer<'a> {
     pub fn new(
         surface: &'a mut Surface,
         doc: &Document,
-        theme: &Theme,
+        theme: &'a Theme,
         offset: Position,
         viewport: Rect,
     ) -> TextRenderer<'a> {
@@ -320,12 +322,19 @@ impl<'a> TextRenderer<'a> {
         };
 
         let text_style = theme.get("ui.text");
+        let basic_style = text_style.patch(
+            theme
+                .try_get("ui.virtual.indent-guide")
+                .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
+        );
 
         let indent_width = doc.indent_style.indent_width(tab_width) as u16;
 
         TextRenderer {
             surface,
             indent_guide_char: editor_config.indent_guides.character.into(),
+            indent_guide_rainbow: editor_config.indent_guides.rainbow_option.clone(),
+            theme,
             newline,
             nbsp,
             nnbsp,
@@ -337,11 +346,7 @@ impl<'a> TextRenderer<'a> {
             starting_indent: offset.col / indent_width as usize
                 + (offset.col % indent_width as usize != 0) as usize
                 + editor_config.indent_guides.skip_levels as usize,
-            indent_guide_style: text_style.patch(
-                theme
-                    .try_get("ui.virtual.indent-guide")
-                    .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
-            ),
+            indent_guide_style: basic_style,
             text_style,
             draw_indent_guides: editor_config.indent_guides.render,
             viewport,
@@ -486,8 +491,25 @@ impl<'a> TextRenderer<'a> {
                 as u16;
             let y = self.viewport.y + row;
             debug_assert!(self.surface.in_bounds(x, y));
-            self.surface
-                .set_string(x, y, &self.indent_guide_char, self.indent_guide_style);
+            match self.indent_guide_rainbow {
+                RainbowIndentOptions::None => {
+                    self.surface
+                        .set_string(x, y, &self.indent_guide_char, self.indent_guide_style)
+                }
+                RainbowIndentOptions::Dim => {
+                    let new_style = self
+                        .indent_guide_style
+                        .patch(self.theme.get_rainbow(i))
+                        .add_modifier(Modifier::DIM);
+                    self.surface
+                        .set_string(x, y, &self.indent_guide_char, new_style);
+                }
+                RainbowIndentOptions::Normal => {
+                    let new_style = self.indent_guide_style.patch(self.theme.get_rainbow(i));
+                    self.surface
+                        .set_string(x, y, &self.indent_guide_char, new_style);
+                }
+            };
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -924,11 +924,20 @@ impl Default for WhitespaceCharacters {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RainbowIndentOptions {
+    None,
+    Dim,
+    Normal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
     pub skip_levels: u8,
+    pub rainbow_option: RainbowIndentOptions,
 }
 
 impl Default for IndentGuidesConfig {
@@ -937,6 +946,7 @@ impl Default for IndentGuidesConfig {
             skip_levels: 0,
             render: false,
             character: '│',
+            rainbow_option: RainbowIndentOptions::None,
         }
     }
 }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -395,13 +395,14 @@ impl Theme {
     }
 
     fn from_keys(toml_keys: Map<String, Value>) -> (Self, Vec<String>) {
-        let (styles, scopes, highlights, load_errors, _rainbow_length) =
+        let (styles, scopes, highlights, load_errors, rainbow_length) =
             build_theme_values(toml_keys);
 
         let theme = Self {
             styles,
             scopes,
             highlights,
+            rainbow_length,
             ..Default::default()
         };
         (theme, load_errors)

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -227,6 +227,7 @@ pub struct Theme {
     // tree-sitter highlight styles are stored in a Vec to optimize lookups
     scopes: Vec<String>,
     highlights: Vec<Style>,
+    rainbow_length: usize,
 }
 
 impl From<Value> for Theme {
@@ -255,10 +256,17 @@ impl<'de> Deserialize<'de> for Theme {
 
 fn build_theme_values(
     mut values: Map<String, Value>,
-) -> (HashMap<String, Style>, Vec<String>, Vec<Style>, Vec<String>) {
+) -> (
+    HashMap<String, Style>,
+    Vec<String>,
+    Vec<Style>,
+    Vec<String>,
+    usize,
+) {
     let mut styles = HashMap::new();
     let mut scopes = Vec::new();
     let mut highlights = Vec::new();
+    let mut rainbow_length = 0;
 
     let mut warnings = Vec::new();
 
@@ -277,6 +285,27 @@ fn build_theme_values(
     styles.reserve(values.len());
     scopes.reserve(values.len());
     highlights.reserve(values.len());
+
+    for (i, style) in values
+        .remove("rainbow")
+        .and_then(|value| match palette.parse_style_array(value) {
+            Ok(styles) => Some(styles),
+            Err(err) => {
+                warn!("{}", err);
+                None
+            }
+        })
+        .unwrap_or_else(default_rainbow)
+        .iter()
+        .enumerate()
+    {
+        let name = format!("rainbow.{}", i);
+        styles.insert(name.clone(), *style);
+        scopes.push(name);
+        highlights.push(*style);
+        rainbow_length += 1;
+    }
+
     for (name, style_value) in values {
         let mut style = Style::default();
         if let Err(err) = palette.parse_style(&mut style, style_value) {
@@ -289,7 +318,7 @@ fn build_theme_values(
         highlights.push(style);
     }
 
-    (styles, scopes, highlights, warnings)
+    (styles, scopes, highlights, warnings, rainbow_length)
 }
 
 impl Theme {
@@ -366,7 +395,8 @@ impl Theme {
     }
 
     fn from_keys(toml_keys: Map<String, Value>) -> (Self, Vec<String>) {
-        let (styles, scopes, highlights, load_errors) = build_theme_values(toml_keys);
+        let (styles, scopes, highlights, load_errors, _rainbow_length) =
+            build_theme_values(toml_keys);
 
         let theme = Self {
             styles,
@@ -376,6 +406,25 @@ impl Theme {
         };
         (theme, load_errors)
     }
+
+    pub fn rainbow_length(&self) -> usize {
+        self.rainbow_length
+    }
+
+    pub fn get_rainbow(&self, index: usize) -> Style {
+        self.highlights[index % self.rainbow_length]
+    }
+}
+
+fn default_rainbow() -> Vec<Style> {
+    vec![
+        Style::default().fg(Color::Red),
+        Style::default().fg(Color::Yellow),
+        Style::default().fg(Color::Green),
+        Style::default().fg(Color::Blue),
+        Style::default().fg(Color::Cyan),
+        Style::default().fg(Color::Magenta),
+    ]
 }
 
 struct ThemePalette {
@@ -518,6 +567,24 @@ impl ThemePalette {
         }
         Ok(())
     }
+
+    /// Parses a TOML array into a [`Vec`] of [`Style`]. If the value cannot be
+    /// parsed as an array or if any style in the array cannot be parsed then an
+    /// error is returned.
+    pub fn parse_style_array(&self, value: Value) -> Result<Vec<Style>, String> {
+        let mut styles = Vec::new();
+
+        for v in value
+            .as_array()
+            .ok_or_else(|| format!("Theme: could not parse value as an array: '{}'", value))?
+        {
+            let mut style = Style::default();
+            self.parse_style(&mut style, v.clone())?;
+            styles.push(style);
+        }
+
+        Ok(styles)
+    }
 }
 
 impl TryFrom<Value> for ThemePalette {
@@ -591,5 +658,52 @@ mod tests {
                 .bg(Color::Rgb(0, 0, 0))
                 .add_modifier(Modifier::BOLD)
         );
+    }
+
+    #[test]
+    fn test_parse_valid_style_array() {
+        let theme = toml::toml! {
+            rainbow = ["#ff0000", "#ffa500", "#fff000", { fg = "#00ff00", modifiers = ["bold"] }]
+        };
+
+        let palette = ThemePalette::default();
+
+        let rainbow = theme.get("rainbow").unwrap();
+        let parse_result = palette.parse_style_array(rainbow.clone());
+
+        assert_eq!(
+            Ok(vec![
+                Style::default().fg(Color::Rgb(255, 0, 0)),
+                Style::default().fg(Color::Rgb(255, 165, 0)),
+                Style::default().fg(Color::Rgb(255, 240, 0)),
+                Style::default()
+                    .fg(Color::Rgb(0, 255, 0))
+                    .add_modifier(Modifier::BOLD),
+            ]),
+            parse_result
+        )
+    }
+
+    #[test]
+    fn test_parse_invalid_style_array() {
+        let palette = ThemePalette::default();
+
+        let theme = toml::toml! { invalid_hex_code = ["#f00"] };
+        let invalid_hex_code = theme.get("invalid_hex_code").unwrap();
+        let parse_result = palette.parse_style_array(invalid_hex_code.clone());
+
+        assert_eq!(
+            Err("Theme: malformed hexcode: #f00".to_string()),
+            parse_result
+        );
+
+        let theme = toml::toml! { not_an_array = { red = "#ff0000" } };
+        let not_an_array = theme.get("not_an_array").unwrap();
+        let parse_result = palette.parse_style_array(not_an_array.clone());
+
+        assert_eq!(
+            Err("Theme: could not parse value as an array: '{ red = \"#ff0000\" }'".to_string()),
+            parse_result
+        )
     }
 }

--- a/runtime/themes/catppuccin_latte.toml
+++ b/runtime/themes/catppuccin_latte.toml
@@ -1,5 +1,7 @@
 inherits = "catppuccin_mocha"
 
+rainbow = ["red", "yellow", "green", "blue", "teal", "pink"]
+
 [palette]
 rosewater = "#dc8a78"
 flamingo = "#dd7878"

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -121,6 +121,8 @@
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
 
+rainbow = ["red", "yellow", "green", "blue", "teal", "pink"]
+
 error = "red"
 warning = "yellow"
 info = "sky"


### PR DESCRIPTION
### Usage

This feature will be opt-in, i.e. disabled by default. Enable it in your `config.toml` as follows:

```toml
[editor.indent-guides]
render = true
rainbow-option = "normal"  # supports "normal", "dim", "none"
```

### Theming

A theme can define a rainbow palette as follows (e.g. by referencing palette colors):
```
rainbow = ["red", "yellow", "green", "blue", "teal", "pink"]
```

If a theme does not define or inherit any rainbow palette, a standard color palette will be used.

In this PR the "catppuccin" themes define a custom rainbow palette.

### Preview

catppuccin_macchiato:
![image](https://github.com/user-attachments/assets/d927e70c-2cad-49c6-b206-8a514f2d811d)

catppuccin_latte:
![image](https://github.com/user-attachments/assets/06c9e25c-baf1-4a11-9525-6483711a5da1)

_image courtesy of the original PR author_:
![image](https://github.com/user-attachments/assets/6a6e75fc-48bc-4043-ad8f-0c81419fdebe)

### Known issues

Dimming does not work. If `rainbow-option` is set to `dim`, it will likely act as if set to `normal`.

---

This pull request introduces colored indentation guides, a.k.a. rainbow indentation guides.

This is https://github.com/helix-editor/helix/pull/4493 (which in turn was a continuation of https://github.com/helix-editor/helix/pull/4056), squashed and rebased, and with conflicts resolved.

> [!NOTE]
> This makes considerable changes in the upstream implementation, and may never be merged upstream. We may have to refactor this implementation in the near future to avoid further conflicts.

Suggested in #42.