### PR TITLE
Map vi/va keys to the Helix mi/ma behavior

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -756,6 +756,9 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         "k" | "up" => extend_anchored_visual_line_up,
         "l" | "right" => extend_same_line_char_right,
 
+        "a" => select_textobject_around,
+        "i" => select_textobject_inner,
+
         //"w" => extend_next_word_start,
         //"b" => extend_prev_word_start,
         //"e" => extend_next_word_end,


### PR DESCRIPTION
This simply maps `vi`/`va` keys to the Helix `mi`/`ma` behaviour. It's a small change, but it brings the behavior closer to what users familiar with Vim would expect.