### PR TITLE
Add Vim-style * and # key search

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -653,6 +653,8 @@ impl MappableCommand {
         evil_till_prev_char, "Move till previous occurrence of char (evil)",
         evil_find_prev_char, "Move to previous occurrence of char (evil)",
         evil_append_mode, "Append after character",
+        evil_cursor_forward_search, "Search forward for the word near cursor (evil)",
+        evil_cursor_backward_search, "Search backward for the word near cursor (evil)",
         command_palette, "Open command palette",
         goto_word, "Jump to a two-character label",
         extend_to_word, "Extend to a two-character label",
@@ -5836,6 +5838,30 @@ fn select_textobject_around(cx: &mut Context) {
 
 fn select_textobject_inner(cx: &mut Context) {
     select_textobject(cx, textobject::TextObject::Inside);
+}
+
+fn evil_cursor_forward_search(cx: &mut Context) {
+    select_inside_word(cx);
+    search_selection(cx);
+    search_next(cx);
+}
+
+fn evil_cursor_backward_search(cx: &mut Context) {
+    select_inside_word(cx);
+    search_selection(cx);
+    search_prev(cx);
+}
+
+fn select_inside_word(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+
+    let objtype = textobject::TextObject::Inside;
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        textobject::textobject_word(text, range, objtype, count, false)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5873,6 +5873,7 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
         doc.set_selection(view.id, selection);
     }
 
+    exit_select_mode(cx);
     keep_primary_selection(cx);
 
     let count = cx.count();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5842,13 +5842,13 @@ fn select_textobject_inner(cx: &mut Context) {
 
 fn evil_cursor_forward_search(cx: &mut Context) {
     select_inside_word(cx);
-    search_selection(cx);
+    search_selection_detect_word_boundaries(cx);
     search_next(cx);
 }
 
 fn evil_cursor_backward_search(cx: &mut Context) {
     select_inside_word(cx);
-    search_selection(cx);
+    search_selection_detect_word_boundaries(cx);
     search_prev(cx);
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5848,7 +5848,10 @@ fn evil_cursor_backward_search(cx: &mut Context) {
     evil_cursor_search_impl(cx, Direction::Backward);
 }
 
-fn evil_cursor_search_impl (cx: &mut Context, direction: Direction) {
+fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
+    fn find_keyword_char(slice: RopeSlice) -> Option<usize> {
+        slice.chars().position(|ch| ch.is_alphanumeric() || ch == '_')
+    }
     fn goto_next_non_blank_in_line(view: &mut View, doc: &mut Document, movement: Movement) {
         let text = doc.text().slice(..);
 
@@ -5861,9 +5864,9 @@ fn evil_cursor_search_impl (cx: &mut Context, direction: Direction) {
 
             let anchor = range.cursor(text);
 
-            if let Some(pos) = text.slice(anchor..pos_end + 1).first_non_whitespace_char() {
+            if let Some(pos) = find_keyword_char(text.slice(anchor..pos_end + 1)){
                 range.put_cursor(text, anchor + pos, movement == Movement::Extend)
-            } else{
+            } else {
                 range.put_cursor(text, anchor, movement == Movement::Extend)
             }
         });
@@ -5894,7 +5897,6 @@ fn evil_cursor_search_impl (cx: &mut Context, direction: Direction) {
     let config = cx.editor.config();
     if config.search.smart_case {
         let register = cx.register.unwrap_or('/');
-
         let regex = match cx.editor.registers.first(register, cx.editor) {
             Some(regex) => regex,
             None => return,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5863,8 +5863,8 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
                 .max(line_start);
 
             let anchor = range.cursor(text);
-
-            if let Some(pos) = find_keyword_char(text.slice(anchor..pos_end + 1)){
+            let search_limit = (pos_end + 1).min(text.len_chars());
+            if let Some(pos) = find_keyword_char(text.slice(anchor..search_limit)){
                 range.put_cursor(text, anchor + pos, movement == Movement::Extend)
             } else {
                 range.put_cursor(text, anchor, movement == Movement::Extend)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5880,20 +5880,19 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
     goto_next_keyword_char_in_line(view, doc);
 
     let text = doc.text().slice(..);
-
-    let objtype = textobject::TextObject::Inside;
-    let selection = doc.selection(view.id).clone().transform(|range| {
-        textobject::textobject_word(text, range, objtype, count, false)
-    });
+    let selection = doc.selection(view.id);
 
     if selection.primary().fragment(text).trim().is_empty() {
         cx.editor.set_error("No string under cursor");
         return;
     }
 
-    doc.set_selection(view.id, selection);
-
     // Use Helix 'word' as a Vim 'keyword' equivalent
+    let objtype = textobject::TextObject::Inside;
+    let selection = selection.clone().transform(|range| {
+        textobject::textobject_word(text, range, objtype, count, false)
+    });
+    doc.set_selection(view.id, selection);
     search_selection_detect_word_boundaries(cx);
 
     // if smart case enabled, replace register with lower case

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5873,6 +5873,8 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
         doc.set_selection(view.id, selection);
     }
 
+    keep_primary_selection(cx);
+
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
     goto_next_keyword_char_in_line(view, doc);
@@ -5884,8 +5886,7 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
         textobject::textobject_word(text, range, objtype, count, false)
     });
 
-    if selection.len() < 2 &&
-       selection.primary().fragment(text).trim().is_empty() {
+    if selection.primary().fragment(text).trim().is_empty() {
         cx.editor.set_error("No string under cursor");
         return;
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5896,26 +5896,22 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
     doc.set_selection(view.id, selection);
     search_selection_detect_word_boundaries(cx);
 
-    // if smart case enabled, replace register with lower case
-    let config = cx.editor.config();
-    if config.search.smart_case {
-        let register = cx.register.unwrap_or('/');
-        let regex = match cx.editor.registers.first(register, cx.editor) {
-            Some(regex) => regex,
-            None => return,
-        }
-        .to_lowercase();
+    // Vim */# search is case insensitive, thus prepending (?i) to regex
+    let register = cx.register.unwrap_or('/');
+    let regex = match cx.editor.registers.first(register, cx.editor) {
+        Some(regex) => format!("(?i){}", regex),
+        None => return,
+    };
 
-        let msg = format!("register '{}' set to '{}'", register, &regex);
-        match cx.editor.registers.push(register, regex) {
-            Ok(_) => {
-                cx.editor.registers.last_search_register = register;
-                cx.editor.set_status(msg)
-            }
-            Err(err) => {
-                cx.editor.set_error(format!("Failed to update register: {}", err));
-                return;
-            }
+    let msg = format!("register '{}' set to '{}'", register, &regex);
+    match cx.editor.registers.push(register, regex) {
+        Ok(_) => {
+            cx.editor.registers.last_search_register = register;
+            cx.editor.set_status(msg)
+        }
+        Err(err) => {
+            cx.editor.set_error(format!("Failed to update register: {}", err));
+            return;
         }
     }
     search_next_or_prev_impl(cx, Movement::Move, direction);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5867,7 +5867,9 @@ fn evil_cursor_backward_search(cx: &mut Context) {
 
 fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
     fn find_keyword_char(slice: RopeSlice) -> Option<usize> {
-        slice.chars().position(|ch| ch.is_alphanumeric() || ch == '_')
+        slice
+            .chars()
+            .position(|ch| ch.is_alphanumeric() || ch == '_')
     }
     fn goto_next_keyword_char_in_line(view: &mut View, doc: &mut Document) {
         let text = doc.text().slice(..);
@@ -5881,7 +5883,7 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
 
             let anchor = range.cursor(text);
             let search_limit = (pos_end + 1).min(text.len_chars());
-            if let Some(pos) = find_keyword_char(text.slice(anchor..search_limit)){
+            if let Some(pos) = find_keyword_char(text.slice(anchor..search_limit)) {
                 range.put_cursor(text, anchor + pos, false)
             } else {
                 range.put_cursor(text, anchor, false)
@@ -5907,9 +5909,9 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
 
     // Use Helix 'word' as a Vim 'keyword' equivalent
     let objtype = textobject::TextObject::Inside;
-    let selection = selection.clone().transform(|range| {
-        textobject::textobject_word(text, range, objtype, count, false)
-    });
+    let selection = selection
+        .clone()
+        .transform(|range| textobject::textobject_word(text, range, objtype, count, false));
     doc.set_selection(view.id, selection);
     search_selection_detect_word_boundaries(cx);
 
@@ -5927,7 +5929,8 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
             cx.editor.set_status(msg)
         }
         Err(err) => {
-            cx.editor.set_error(format!("Failed to update register: {}", err));
+            cx.editor
+                .set_error(format!("Failed to update register: {}", err));
             return;
         }
     }
@@ -7022,4 +7025,3 @@ fn evil_goto_line(cx: &mut Context) {
         goto_last_line(cx);
     }
 }
-

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5915,7 +5915,8 @@ fn evil_cursor_search_impl(cx: &mut Context, direction: Direction) {
     doc.set_selection(view.id, selection);
     search_selection_detect_word_boundaries(cx);
 
-    // Vim */# search is case insensitive, thus prepending (?i) to regex
+    // Make the search case insensitive by prepending (?i) to the regex
+    // TODO: consider supporting case sensitive searching depending on search.smart-case
     let register = cx.register.unwrap_or('/');
     let regex = match cx.editor.registers.first(register, cx.editor) {
         Some(regex) => format!("(?i){}", regex),

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -541,7 +541,10 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         "?" => rsearch,
         "n" => search_next,
         "N" => search_prev,
-        "*" => search_selection,
+        //"*" => search_selection,
+
+        "*" => evil_cursor_forward_search,
+        "#" => evil_cursor_backward_search,
 
         "u" => undo,
         "U" => redo,


### PR DESCRIPTION
Related to #16 . This PR adds behaviour similar to the `*` and `#` keys in Vim. 

> `*` key: Search forward for the word near cursor.
> `#` key: Search backward for the word near cursor.