### PR TITLE
Visual line mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These are the current differences compared to the upstream project:
 	-	Commands: `a`, `c`, `d`, `y`, `x`
 	-	Modifiers: `i`
 	-	Motions: `w`, `W`, `e`, `E`, `b`, `B`, `0`, `$`
+	-	Visual line mode: `V`
 -	Adjusted defaults ([511060a](https://github.com/usagi-flow/evil-helix/commit/511060abcfcbe9377ec50e8a0ecaf4c0660776bb)):
 	-	The Helix "SEL" mode is called "VIS"
 	-	Smart tab is disabled by default

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -633,6 +633,19 @@ impl Selection {
         selection.normalize()
     }
 
+    pub fn evil_new_no_normalize(ranges: SmallVec<[Range; 1]>, primary_index: usize) -> Self {
+        // Copy/paste of `new`, without the call to `normalize`.
+        assert!(!ranges.is_empty());
+        debug_assert!(primary_index < ranges.len());
+
+        let selection = Self {
+            ranges,
+            primary_index,
+        };
+
+        selection
+    }
+
     /// Takes a closure and maps each `Range` over the closure.
     pub fn transform<F>(mut self, mut f: F) -> Self
     where
@@ -642,6 +655,17 @@ impl Selection {
             *range = f(*range)
         }
         self.normalize()
+    }
+
+    pub fn evil_transform_no_normalize<F>(mut self, mut f: F) -> Self
+    where
+        F: FnMut(Range) -> Range,
+    {
+        // Copy/paste of `transform`, without the call to `normalize`.
+        for range in self.ranges.iter_mut() {
+            *range = f(*range)
+        }
+        self
     }
 
     /// Takes a closure and maps each `Range` over the closure to multiple `Range`s.
@@ -663,6 +687,11 @@ impl Selection {
     pub fn ensure_invariants(self, text: RopeSlice) -> Self {
         self.transform(|r| r.min_width_1(text).grapheme_aligned(text))
             .normalize()
+    }
+
+    pub fn evil_ensure_invariants_no_normalize(self, text: RopeSlice) -> Self {
+        // Copy/paste of `ensure_invariants`, without the call to `normalize`.
+        self.evil_transform_no_normalize(|r| r.min_width_1(text).grapheme_aligned(text))
     }
 
     /// Transforms the selection into all of the left-side head positions,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -16,6 +16,7 @@ pub use lsp::*;
 use tui::text::Span;
 pub use typed::*;
 
+use helix_core::smallvec;
 use helix_core::{
     char_idx_at_visual_offset,
     chars::char_is_word,
@@ -127,6 +128,20 @@ impl Context<'_> {
         &mut self,
         on_next_key_callback: impl FnOnce(&mut Context, KeyEvent) + 'static,
     ) {
+        if evil_is_select_mode_linewise(self) {
+            return self.on_next_key_callback = Some((
+                Box::new(|cx: &mut Context, e: KeyEvent| {
+                    // See NOTE LineWise Select
+                    keep_primary_selection(cx);
+                    on_next_key_callback(cx, e);
+                    if evil_is_select_mode_linewise(cx) {
+                        evil_transform_selection_linewise(cx)
+                    }
+                }),
+                OnKeyCallbackKind::PseudoPending,
+            ));
+        };
+
         self.on_next_key_callback = Some((
             Box::new(on_next_key_callback),
             OnKeyCallbackKind::PseudoPending,
@@ -242,6 +257,28 @@ macro_rules! static_commands {
 
 impl MappableCommand {
     pub fn execute(&self, cx: &mut Context) {
+        if evil_is_select_mode_linewise(cx) {
+            // NOTE LineWise Select
+            // ======================
+            // We are in LineWise Select mode, so we have a selection
+            // with two overlapping ranges: the primary (helix) range
+            // and a secondary (evil-helix only) range that stretches
+            // until the end of the line.
+            //
+            // The command that we are currently processing is likely
+            // going to call `selection.transform`, which calls
+            // `selection.normalize` afterwards, which merges all
+            // overlapping ranges into a single range and puts the
+            // cursor at the end of that range. This is not what we
+            // want (we'd lose track of the cursor position).
+            //
+            // Therefore we:
+            // - first call `keep_primary_selection`
+            // - then process the command using the primary range only
+            // - then create the new secondary range (below)
+            keep_primary_selection(cx)
+        }
+
         match &self {
             Self::Typable { name, args, doc: _ } => {
                 let args: Vec<Cow<str>> = args.iter().map(Cow::from).collect();
@@ -274,6 +311,10 @@ impl MappableCommand {
                     cx.editor.macro_replaying.pop();
                 }));
             }
+        }
+
+        if evil_is_select_mode_linewise(cx) {
+            evil_transform_selection_linewise(cx)
         }
     }
 
@@ -3878,6 +3919,7 @@ pub fn select_mode(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 
     cx.editor.mode = Mode::Select;
+    cx.editor.evil_select_mode = EvilSelectMode::CharacterWise;
 }
 
 pub fn exit_select_mode(cx: &mut Context) {
@@ -6758,6 +6800,9 @@ fn evil_delete(cx: &mut Context) {
 }
 
 fn evil_delete_immediate(cx: &mut Context) {
+    if evil_is_select_mode_linewise(cx) {
+        extend_to_line_bounds(cx);
+    }
     EvilCommands::delete_immediate(cx);
 }
 
@@ -6815,6 +6860,55 @@ fn evil_linewise_select_mode(cx: &mut Context) {
             EvilSelectMode::CharacterWise => switch_to_linewise(cx),
         }
     }
+}
+
+fn evil_is_select_mode_linewise(cx: &Context) -> bool {
+    if cx.editor.mode == Mode::Select {
+        match cx.editor.evil_select_mode {
+            EvilSelectMode::LineWise => true,
+            EvilSelectMode::CharacterWise => false,
+        }
+    } else {
+        false
+    }
+}
+
+fn evil_transform_selection_linewise(cx: &mut Context) {
+    // LineWise Select
+    // ===============
+    // This function creates a selection with two overlapping ranges.
+    //
+    // It take the primary range and, assuming it is in the forward direction,
+    // moves its anchor to the start of the line. Then it creates a secondary
+    // selection from the end of the line to the the cursor. So the cursors of
+    // the two ranges are overlapping. To the user this should look like a
+    // single selection with the cursor somewhere in the middle of the last
+    // line, just like Vim does in linewise visual mode.
+    //
+    // Do not call `normalize` on the selection, as it would merge them.
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let range = doc.selection(view.id).clone().primary(); // TODO: handle more than 1 selection?
+
+    // Copy/paste from `extend_to_line_bounds`.
+    let (start_line, end_line) = range.line_range(text.slice(..));
+    let start = text.line_to_char(start_line);
+    let end = text.line_to_char((end_line + 1).min(text.len_lines()));
+
+    let selection = if range.direction() == Direction::Forward {
+        let primary = Range::new(start, range.head);
+        let secondary = Range::new(end, graphemes::prev_grapheme_boundary(text, range.head));
+        Selection::evil_new_no_normalize(smallvec![primary, secondary], 0)
+    } else {
+        let primary = Range::new(end, range.head);
+        let secondary = Range::new(start, graphemes::next_grapheme_boundary(text, range.head));
+        Selection::evil_new_no_normalize(
+            // Sorted by [Range::from]
+            smallvec![secondary, primary],
+            1,
+        )
+    };
+    doc.evil_set_selection_no_normalize(view.id, selection);
 }
 
 fn evil_append_mode(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -40,6 +40,7 @@ use helix_core::{
     visual_offset_from_block, Deletion, LineEnding, Position, Range, Rope, RopeGraphemes,
     RopeReader, RopeSlice, Selection, SmallVec, Syntax, Tendril, Transaction,
 };
+use helix_view::editor::EvilSelectMode;
 use helix_view::{
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
     editor::Action,
@@ -614,6 +615,8 @@ impl MappableCommand {
         command_palette, "Open command palette",
         goto_word, "Jump to a two-character label",
         extend_to_word, "Extend to a two-character label",
+        evil_characterwise_select_mode, "Enter/exit characterwise select mode",
+        evil_linewise_select_mode, "Enter/exit linewise select mode",
         goto_next_tabstop, "goto next snippet placeholder",
         goto_prev_tabstop, "goto next snippet placeholder",
     );
@@ -6780,6 +6783,38 @@ fn evil_till_prev_char(cx: &mut Context) {
 
 fn evil_find_prev_char(cx: &mut Context) {
     EvilCommands::find_char(cx, find_char, Direction::Backward, true)
+}
+
+fn evil_characterwise_select_mode(cx: &mut Context) {
+    fn switch_to_characterwise(cx: &mut Context) {
+        cx.editor.evil_select_mode = EvilSelectMode::CharacterWise;
+    }
+
+    if cx.editor.mode != Mode::Select {
+        select_mode(cx);
+        switch_to_characterwise(cx);
+    } else {
+        match cx.editor.evil_select_mode {
+            EvilSelectMode::LineWise => switch_to_characterwise(cx),
+            EvilSelectMode::CharacterWise => exit_select_mode(cx),
+        }
+    }
+}
+
+fn evil_linewise_select_mode(cx: &mut Context) {
+    fn switch_to_linewise(cx: &mut Context) {
+        cx.editor.evil_select_mode = EvilSelectMode::LineWise;
+    }
+
+    if cx.editor.mode != Mode::Select {
+        select_mode(cx);
+        switch_to_linewise(cx);
+    } else {
+        match cx.editor.evil_select_mode {
+            EvilSelectMode::LineWise => exit_select_mode(cx),
+            EvilSelectMode::CharacterWise => switch_to_linewise(cx),
+        }
+    }
 }
 
 fn evil_append_mode(cx: &mut Context) {

--- a/helix-term/src/commands/evil.rs
+++ b/helix-term/src/commands/evil.rs
@@ -13,6 +13,7 @@ use helix_core::{doc_formatter::TextFormat, text_annotations::TextAnnotations, R
 use helix_core::{movement::move_next_word_end, Rope};
 use helix_core::{Range, Selection, Transaction};
 use helix_view::document::Mode;
+use helix_view::editor::EvilSelectMode;
 use helix_view::input::KeyEvent;
 use once_cell::sync::Lazy;
 
@@ -254,8 +255,20 @@ impl EvilCommands {
                 }
             }
             helix_view::document::Mode::Select => {
-                // Yank the selected text
-                selection = Some(doc.selection(view.id).clone());
+                match cx.editor.evil_select_mode {
+                    EvilSelectMode::LineWise => {
+                        selection = Some(Self::get_full_line_based_selection(
+                            cx,
+                            !Self::context()
+                                .command
+                                .is_some_and(|command| command == Command::Change),
+                        ))
+                    }
+                    EvilSelectMode::CharacterWise => {
+                        // Yank the selected text
+                        selection = Some(doc.selection(view.id).clone());
+                    }
+                }
             }
             helix_view::document::Mode::Insert => {
                 log::debug!("Attempted to select while in insert mode");
@@ -703,7 +716,7 @@ impl EvilCommands {
     where
         F: FnOnce(&mut Context, Direction, bool, bool),
     {
-        let extend = false;
+        let extend = true;
         base_fn(cx, direction, inclusive, extend);
         let inner_callback = cx.on_next_key_callback.take();
 

--- a/helix-term/src/commands/evil.rs
+++ b/helix-term/src/commands/evil.rs
@@ -18,13 +18,19 @@ use once_cell::sync::Lazy;
 
 use crate::commands::{enter_insert_mode, exit_select_mode, Context, Extend, Operation};
 
-use super::{select_mode, OnKeyCallbackKind};
+use super::OnKeyCallbackKind;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Command {
     Yank,
     Delete,
     Change,
+}
+
+#[derive(Copy, Clone)]
+enum SetMode {
+    Normal,
+    Insert,
 }
 
 impl TryFrom<char> for Command {
@@ -96,7 +102,7 @@ struct EvilContext {
     motion: Option<Motion>,
     count: Option<usize>,
     modifiers: Vec<Modifier>,
-    set_mode: Option<Mode>,
+    set_mode: Option<SetMode>,
 }
 
 impl EvilContext {
@@ -501,7 +507,7 @@ impl EvilCommands {
         doc.apply(&transaction, view.id);
     }
 
-    fn evil_command(cx: &mut Context, requested_command: Command, set_mode: Option<Mode>) {
+    fn evil_command(cx: &mut Context, requested_command: Command, set_mode: Option<SetMode>) {
         let active_command;
         {
             active_command = Self::context().command;
@@ -548,14 +554,11 @@ impl EvilCommands {
                 let set_mode = Self::context().set_mode;
                 if let Some(mode) = set_mode {
                     match mode {
-                        Mode::Normal => {
+                        SetMode::Normal => {
                             exit_select_mode(cx);
                         }
-                        Mode::Insert => {
+                        SetMode::Insert => {
                             enter_insert_mode(cx);
-                        }
-                        Mode::Select => {
-                            select_mode(cx);
                         }
                     }
                 } else {
@@ -682,8 +685,8 @@ impl EvilCommands {
                 Operation::Change => Command::Change,
             },
             Some(match op {
-                Operation::Delete => Mode::Normal,
-                Operation::Change => Mode::Insert,
+                Operation::Delete => SetMode::Normal,
+                Operation::Change => SetMode::Insert,
             }),
         );
     }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -433,7 +433,8 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         //"B" => move_prev_long_word_start,
         //"E" => move_next_long_word_end,
 
-        "v" => select_mode,
+        "v" => evil_characterwise_select_mode,
+        "V" => evil_linewise_select_mode,
         // TODO (redundant with count + gg anyway?): "G" => goto_line,
         "g" => { "Goto"
             "g" => goto_file_start,
@@ -781,7 +782,6 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         "end" => extend_to_line_end,
         "esc" => exit_select_mode,
 
-        "v" => normal_mode,
         "g" => { "Goto"
             "k" => extend_anchored_line_up,
             "j" => extend_anchored_line_down,

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -138,7 +138,7 @@ where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
     match element_id {
-        helix_view::editor::StatusLineElement::Mode => render_mode,
+        helix_view::editor::StatusLineElement::Mode => evil_render_mode,
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
         helix_view::editor::StatusLineElement::FileBaseName => render_file_base_name,
         helix_view::editor::StatusLineElement::FileName => render_file_name,
@@ -198,6 +198,28 @@ where
             None
         },
     );
+}
+
+fn evil_render_mode<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    render_mode(context, write);
+
+    let visible = context.focused;
+    let config = context.editor.config();
+
+    if visible && context.editor.mode == Mode::Select {
+        write(
+            context,
+            format!("{} ", context.editor.evil_select_mode)
+                .trim_start()
+                .to_string(),
+            config
+                .color_modes
+                .then_some(context.editor.theme.get("ui.statusline.select")),
+        )
+    }
 }
 
 // TODO think about handling multiple language servers

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1246,6 +1246,18 @@ impl Document {
         })
     }
 
+    pub fn evil_set_selection_no_normalize(&mut self, view_id: ViewId, selection: Selection) {
+        // Copy/paste of `set_selection`, without the call to `ensure_invariants`.
+        self.selections.insert(
+            view_id,
+            selection.evil_ensure_invariants_no_normalize(self.text.slice(..)),
+        );
+        helix_event::dispatch(SelectionDidChange {
+            doc: self,
+            view: view_id,
+        });
+    }
+
     /// Find the origin selection of the text in a document, i.e. where
     /// a single cursor would go if it were on the first grapheme. If
     /// the text is empty, returns (0, 0).

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1098,8 +1098,24 @@ pub struct Breakpoint {
 
 use futures_util::stream::{Flatten, Once};
 
+#[derive(Copy, Clone)]
+pub enum EvilSelectMode {
+    CharacterWise,
+    LineWise,
+    //BlockWise,
+}
+
+impl std::fmt::Display for EvilSelectMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CharacterWise => f.write_str(""),
+            Self::LineWise => f.write_str("LINE"),
+        }
+    }
+}
+
 pub struct Editor {
-    pub evil: bool,
+    pub evil_select_mode: EvilSelectMode,
 
     /// Current editing mode.
     pub mode: Mode,
@@ -1253,7 +1269,7 @@ impl Editor {
         area.height -= 1;
 
         Self {
-            evil: conf.evil,
+            evil_select_mode: EvilSelectMode::CharacterWise,
             mode: Mode::Normal,
             tree: Tree::new(area),
             next_document_id: DocumentId::default(),


### PR DESCRIPTION
It's working pretty well I think! Please try it out.

From https://github.com/usagi-flow/evil-helix/pull/56#issuecomment-2646555647:
> However, I see the issue that it's working a bit differently compared to Vim: When entering, the cursor jumps to the end of line, and when moving it within a line (e.g. with b and w), we lose the line selection.

That's all fixed. The cursor doesn't move unless you ask it to.


### Implementation details
I've tried to keep changes to original helix code to a minimum, but some of it is unavoidable.

My initial approach was to add a new mode called `SelectLineWise`. However, this turned out to require too many changes to upstream code, because a lot of code that applies to `Mode::Select` should also apply to `Mode::SelectLineWise`.

The approach I've taken now, similar to the approach taken by #JustBobinArround in #56, is to add a field `cx.editor.evil_select_mode`. This field is only used when we are in Select mode, and it should be considered undefined behavior if you try to read it in Normal mode [^1].


The main idea to add a secondary selection when we are in Visual line mode:  
```
    // LineWise Select
    // ===============
    // This function creates a selection with two overlapping ranges.
    //
    // It take the primary range and, assuming it is in the forward direction,
    // moves its anchor to the start of the line. Then it creates a secondary
    // selection from the end of the line to the the cursor. So the cursors of
    // the two ranges are overlapping. To the user this should look like a
    // single selection with the cursor somewhere in the middle of the last
    // line, just like Vim does in linewise visual mode.
```

The tricky thing is that we don't want to have this secondary selection when processing commands. So that's what the code changes in `Context::on_next_key` and `MappableCommand::execute` are for:

```
            // NOTE LineWise Select
            // ======================
            // We are in LineWise Select mode, so we have a selection
            // with two overlapping ranges: the primary (helix) range
            // and a secondary (evil-helix only) range that stretches
            // until the end of the line.
            //
            // The command that we are currently processing is likely
            // going to call `selection.transform`, which calls
            // `selection.normalize` afterwards, which merges all
            // overlapping ranges into a single range and puts the
            // cursor at the end of that range. This is not what we
            // want (we'd lose track of the cursor position).
            //
            // Therefore we:
            // - first call `keep_primary_selection`
            // - then process the command using the primary range only
            // - then create the new secondary range (below)
```

In the end, these are the functions I had to make changes to, not counting evil methods I added here and there:

In commands.rs:
* Context::on_next_key
* MappableCommand::execute
* select_mode [^2]

In statusline.rs:
* get_render_function

In editor.rs:
* pub struct Editor

### Testing
Passes all tests defined in https://github.com/thomie/vim-keymap-test/blob/master/linewise-visual.test, except test 4: replace line with `Vr1`. I'll need to look into that, but I think this PR is ready for testing by others.

Closes #17.

Related: #51.

[^1]: I did make it an Option at first, but always setting it to None when leaving Select mode requires changing for example `enter_normal_mode` as well, so I didn't do it. And forgetting to set it to None somewhere is perhaps worse than not making the field an Option in the first place. This could be reconsidered.

[^2]: Not strictly necessary, but some users might call this function from their config. I am using for example `D = ["select_mode", "extend_to_line_end", ":clipboard-yank", "flip_selections", "delete_selection"]`, which results in weird behavior if `evil_select_mode` is still set to `EvilSelectMode::LineWise`.
