### PR TITLE
Add } and { keymaps

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -644,6 +644,8 @@ impl MappableCommand {
         evil_prev_long_word_start, "Previous long word start (evil)",
         evil_next_long_word_start, "Next long word start (evil)",
         evil_next_long_word_end, "Next long word end (evil)",
+        evil_goto_next_paragraph, "Goto next paragraph (evil)",
+        evil_goto_prev_paragraph, "Goto previous paragraph (evil)",
         evil_delete, "Delete (evil)",
         evil_delete_immediate, "Delete immediately (evil)",
         evil_yank, "Yank (evil)",
@@ -1423,6 +1425,20 @@ fn goto_prev_paragraph(cx: &mut Context) {
 
 fn goto_next_paragraph(cx: &mut Context) {
     goto_para_impl(cx, movement::move_next_paragraph)
+}
+
+fn evil_goto_next_paragraph(cx: &mut Context) {
+    goto_para_impl(cx, movement::move_next_paragraph);
+    if cx.editor.mode != Mode::Select {
+        EvilCommands::collapse_selections(cx, CollapseMode::ToHead);
+    }
+}
+
+fn evil_goto_prev_paragraph(cx: &mut Context) {
+    goto_para_impl(cx, movement::move_prev_paragraph);
+    if cx.editor.mode != Mode::Select {
+        EvilCommands::collapse_selections(cx, CollapseMode::ToHead);
+    }
 }
 
 fn goto_file_start(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -644,8 +644,8 @@ impl MappableCommand {
         evil_prev_long_word_start, "Previous long word start (evil)",
         evil_next_long_word_start, "Next long word start (evil)",
         evil_next_long_word_end, "Next long word end (evil)",
-        evil_goto_next_paragraph, "Goto next paragraph (evil)",
-        evil_goto_prev_paragraph, "Goto previous paragraph (evil)",
+        evil_move_paragraph_forward, "Move forward by a paragraph (evil)",
+        evil_move_paragraph_backward, "Move backward by a paragraph (evil)",
         evil_delete, "Delete (evil)",
         evil_delete_immediate, "Delete immediately (evil)",
         evil_yank, "Yank (evil)",
@@ -1427,15 +1427,15 @@ fn goto_next_paragraph(cx: &mut Context) {
     goto_para_impl(cx, movement::move_next_paragraph)
 }
 
-fn evil_goto_next_paragraph(cx: &mut Context) {
-    goto_para_impl(cx, movement::move_next_paragraph);
+fn evil_move_paragraph_forward(cx: &mut Context) {
+    goto_para_impl(cx, evil_movement_paragraph_forward);
     if cx.editor.mode != Mode::Select {
         EvilCommands::collapse_selections(cx, CollapseMode::ToHead);
     }
 }
 
-fn evil_goto_prev_paragraph(cx: &mut Context) {
-    goto_para_impl(cx, movement::move_prev_paragraph);
+fn evil_move_paragraph_backward(cx: &mut Context) {
+    goto_para_impl(cx, evil_movement_paragraph_backward);
     if cx.editor.mode != Mode::Select {
         EvilCommands::collapse_selections(cx, CollapseMode::ToHead);
     }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -537,8 +537,8 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
             "space" => add_newline_below,
         },
 
-        "}" => evil_goto_next_paragraph,
-        "{" => evil_goto_prev_paragraph,
+        "}" => evil_move_paragraph_forward,
+        "{" => evil_move_paragraph_backward,
 
         "/" => search,
         "?" => rsearch,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -537,6 +537,9 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
             "space" => add_newline_below,
         },
 
+        "}" => evil_goto_next_paragraph,
+        "{" => evil_goto_prev_paragraph,
+
         "/" => search,
         "?" => rsearch,
         "n" => search_next,


### PR DESCRIPTION
This is related to issue #63 and #28. 

First commit: maps `}` and `{` to helix `]p` and `[p` behavior, but without removing evil-helix visual mode.
Second commit: Adds way more code just to get the behavior exactly like Vim. (no changes to upstream).

Not sure which direction is better: simple or exactly matching Vim.