### PR TITLE
Add caret (^) keymap

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -747,6 +747,7 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
 
         "0" => goto_line_start,
         "$" => goto_line_end,
+        "^" => goto_first_nonwhitespace,
         "G" => goto_last_line,
         "del" => delete_selection,
     });


### PR DESCRIPTION
Map `^` to `gs` behavior!

> `^`     goto the first non-blank character of the line.

I already implemented this feature, only to find out it already exists in Helix!