### PR TITLE
Add more commands to Jumplist using pre-execution 'hooks'

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1448,6 +1448,7 @@ fn goto_next_paragraph(cx: &mut Context) {
 }
 
 fn evil_move_paragraph_forward(cx: &mut Context) {
+    evil_save_to_jumplist(cx);
     goto_para_impl(cx, evil_movement_paragraph_forward);
     if cx.editor.mode != Mode::Select {
         EvilCommands::collapse_selections(cx, CollapseMode::ToHead);
@@ -1455,6 +1456,7 @@ fn evil_move_paragraph_forward(cx: &mut Context) {
 }
 
 fn evil_move_paragraph_backward(cx: &mut Context) {
+    evil_save_to_jumplist(cx);
     goto_para_impl(cx, evil_movement_paragraph_backward);
     if cx.editor.mode != Mode::Select {
         EvilCommands::collapse_selections(cx, CollapseMode::ToHead);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -255,8 +255,27 @@ macro_rules! static_commands {
     }
 }
 
+fn evil_save_to_jumplist(cx: &mut Context){
+        let (view, doc) = current!(cx.editor);
+        push_jump(view, doc);
+}
+
+fn evil_pre_commands_hook(cx: &mut Context, cmd: &MappableCommand)
+{
+    if let MappableCommand::Static { name, .. } = cmd {
+        match *name {
+            n if n.contains("search") || n == "match_brackets" => {
+                evil_save_to_jumplist(cx);
+            }
+            _ => {}
+        }
+    }
+}
+
 impl MappableCommand {
     pub fn execute(&self, cx: &mut Context) {
+        evil_pre_commands_hook(cx, self);
+
         if evil_is_select_mode_linewise(cx) {
             // NOTE LineWise Select
             // ======================


### PR DESCRIPTION
Fix #89  and more Jumplist related issues. An alternative approach to #98 . It utilizes pre-execution "hooks" to add more `Jumplist` points. I'm not sure which approach is better.

This PR is more a question/discussion than a contribution. This approach sacrifices a small performance penalty. However, I think it's better than sprinkling changes to upstream code. Moreover, it will simplify adding more features later on without touching upstream (beside adding one call in the command executor). What do you think? I'm also not sure if using strings is ok, but it makes the code smaller.

**Note:** I still need to check what Jumplist points we are missing, this is still a draft.