### PR TITLE
feat(ci): add a release build target for `x86_64-unknown-linux-musl` (`amd64-linux-musl`)

### DIFF
--- a/.github/workflows/evil-build-tag.yml
+++ b/.github/workflows/evil-build-tag.yml
@@ -30,6 +30,10 @@ jobs:
             name: amd64-linux
             native: true
             os: ubuntu-latest
+          - id: x86_64-unknown-linux-musl
+            name: amd64-linux-musl
+            native: false
+            os: ubuntu-latest
           - id: aarch64-unknown-linux-gnu
             name: aarch64-linux
             native: false

--- a/.github/workflows/evil-build-tag.yml
+++ b/.github/workflows/evil-build-tag.yml
@@ -105,11 +105,6 @@ jobs:
           fi
           rm -rf runtime/grammars/sources
           mv -v runtime dist/helix/
-          #cd dist
-
-          #if [[ "$RUNNER_OS" != "Windows" ]]; then
-          #  tar -cvzf "evil-helix-${{ matrix.target.name }}.tar.gz" helix
-          #fi
 
       - name: "Compress dist (tar)"
         shell: bash


### PR DESCRIPTION
Implements #112