### PR TITLE
fix(catppuccin): restore statusline mode colors

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -73,9 +73,9 @@
 
 "ui.statusline" = { fg = "subtext1", bg = "mantle" }
 "ui.statusline.inactive" = { fg = "surface2", bg = "mantle" }
-"ui.statusline.normal" = { fg = "base", bg = "rosewater", modifiers = ["bold"] }
+"ui.statusline.normal" = { fg = "base", bg = "lavender", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "base", bg = "green", modifiers = ["bold"] }
-"ui.statusline.select" = { fg = "base", bg = "lavender", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "base", bg = "flamingo", modifiers = ["bold"] }
 
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }


### PR DESCRIPTION
This reverts a part of the upstream changes made to the catppuccin themes.

### Until now

Until now, we had this the following mode colors in the statusline - as inherited from upstream:

| Mode | Color name |
| --- | --- |
| **NOR** | ![Lavender](https://placehold.co/14x14/7287fd/7287fd.png) `lavender` |
| **INS** | ![Lavender](https://placehold.co/14x14/40a02b/40a02b.png) `green` |
| **VIS** | ![Lavender](https://placehold.co/14x14/dd7878/dd7878.png) `flamingo` |

### The change

Upstream changed it to this:

| Mode | Color name |
| --- | --- |
| **NOR** | ![Lavender](https://placehold.co/14x14/dc8a78/dc8a78.png) `rosewater` |
| **INS** | ![Lavender](https://placehold.co/14x14/40a02b/40a02b.png) `green` |
| **VIS** | ![Lavender](https://placehold.co/14x14/7287fd/7287fd.png) `lavender` |

The upstream PR https://github.com/helix-editor/helix/pull/13262 is, in fact, just taking over changes from the dedicated [catppuccin-helix](https://github.com/catppuccin/helix) repository.

Here we see that they did indeed change the colors according to our observation, and they explain why: https://github.com/catppuccin/helix/pull/64

### Lualine

For reference, Lualine is similar in **NORMAL** and **INSERT**, but has some differences (Lualine/Vim differentiates between more modes than evil-helix does at the moment):

| Mode | Color name |
| --- | --- |
| **NORMAL** | ![Lavender](https://placehold.co/14x14/1e66f5/1e66f5.png) `blue` |
| **INSERT** | ![Lavender](https://placehold.co/14x14/40a02b/40a02b.png) `green` |
| **VISUAL** | ![Lavender](https://placehold.co/14x14/8839ef/8839ef.png) `mauve` |

See: https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/utils/lualine.lua

---

Therefore, taking into consideration these points, this PR restores the old colors:

- The change is confusing: What was blue-ish is now red-ish, and what was red-ish is now blue-ish.
- The red-ish color (previously VIS/SEL, now NOR), changed from `flamingo` to `rosewater`, which decreases the contrast a little bit.
- The change makes our statusline diverge even more from Lualine.
- In Catppuccin's style guide, there is no concept of modes, as far as I'm aware.

We might also get even closer to the Lualine theme in the future, especially if we add support for more modes.