### PR TITLE
fix command `append_mode_same_line`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3265,22 +3265,27 @@ fn append_mode_same_line(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.restore_cursor = true;
     let text = doc.text().slice(..);
+    let end = text.len_chars();
 
     let selection = doc.selection(view.id).clone().transform(|range| {
-        let pos = range.cursor(text);
-        let line = text.char_to_line(pos);
-        let end_char_index = line_end_char_index(&text, line);
-        let pos_is_at_end_of_line = pos == end_char_index;
+        let forward_range = range.with_direction(Direction::Forward);
+        let range_end = forward_range.cursor(text);
+        let line = text.char_to_line(range_end);
+        let line_end_char_index = line_end_char_index(&text, line);
+        let is_at_end_of_line = range_end == line_end_char_index;
 
-        if pos_is_at_end_of_line {
-            range
+        let range_end = if is_at_end_of_line {
+            range_end
         } else {
-            Range::new(
-                range.from(),
-                graphemes::next_grapheme_boundary(doc.text().slice(..), range.to()),
-            )
-        }
+            range.to()
+        };
+        debug_assert!(range_end != end); // we should never butt against the end of the document
+        Range::new(
+            range.from(),
+            graphemes::next_grapheme_boundary(doc.text().slice(..), range_end),
+        )
     });
+
     doc.set_selection(view.id, selection);
 }
 


### PR DESCRIPTION
The PR resolving #65 and #66 contained a bug, that was fixed in another commit. This PR cherry-picks the additional commit containing the fix.

Description:

> If the cursor was not at the end of the selection range, but the range end was a newline,
> `append_mode_same_line` would cause the cursor to jump to a wrong position.
>
> See https://github.com/helix-editor/helix/pull/10576#issuecomment-2990522009 for details.