### PR TITLE
make `C-c` leave insert mode like `esc` (#59)

### DIFF
--- a/helix-term/src/keymap/default_evil.rs
+++ b/helix-term/src/keymap/default_evil.rs
@@ -400,7 +400,8 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         },
     }));
     let insert = keymap!({ "Insert mode"
-        "esc" => normal_mode,
+        // `C-c` leaves insert mode like `esc`, matching Vim.
+        "esc" | "C-c" => normal_mode,
 
         "C-s" => commit_undo_checkpoint,
         "C-x" => completion,


### PR DESCRIPTION
Straightforward fix for #59 and #148. `C-c` in normal and select mode is left bound to `toggle_comments` (the upstream default), so the line/selection comment-toggle workflow is unaffected.