### PR TITLE
Move cursor back when leaving insert mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -675,6 +675,7 @@ impl MappableCommand {
         evil_goto_line_or_last_line, "Goto last line (evil)",
         evil_characterwise_select_mode, "Enter/exit characterwise select mode",
         evil_linewise_select_mode, "Enter/exit linewise select mode",
+        evil_normal_mode, "Exit insert mode, moving the cursor back like Vim (evil)",
         command_palette, "Open command palette",
         goto_word, "Jump to a two-character label",
         extend_to_word, "Extend to a two-character label",
@@ -7325,6 +7326,27 @@ fn evil_append_mode(cx: &mut Context) {
 
     append_mode_same_line(cx);
     collapse_selection(cx);
+}
+
+/// Leave insert mode and move the cursor back onto the last edited character,
+/// like Vim (which steps the cursor left when leaving insert mode). The step is
+/// clamped to the line start, so it never crosses onto the previous line.
+fn evil_normal_mode(cx: &mut Context) {
+    normal_mode(cx);
+
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let cursor = range.cursor(text);
+        let line_start = text.line_to_char(text.char_to_line(cursor));
+        let pos = if cursor > line_start {
+            graphemes::prev_grapheme_boundary(text, cursor)
+        } else {
+            cursor
+        };
+        Range::point(pos)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn evil_goto_line_or_first_line(cx: &mut Context) {

--- a/helix-term/src/commands/evil.rs
+++ b/helix-term/src/commands/evil.rs
@@ -194,9 +194,6 @@ impl EvilCommands {
         doc.set_selection(
             view.id,
             doc.selection(view.id).clone().transform(|mut range| {
-                // TODO: when exiting insert mode after appending, we end up on the character _after_ the curson,
-                // while vim returns to the character _before_ the cursor.
-
                 match collapse_mode {
                     CollapseMode::Forward => {
                         let end = range.anchor.max(range.head);

--- a/helix-term/src/keymap/default_evil.rs
+++ b/helix-term/src/keymap/default_evil.rs
@@ -400,7 +400,7 @@ pub fn default_evil() -> HashMap<Mode, KeyTrie> {
         },
     }));
     let insert = keymap!({ "Insert mode"
-        "esc" => normal_mode,
+        "esc" => evil_normal_mode,
 
         "C-s" => commit_undo_checkpoint,
         "C-x" => completion,


### PR DESCRIPTION
Get around #123 and the TODO: create a new `evil_normal_mode`, which exits like `normal_mode` and then steps the cursor back one grapheme, clamped to the line start. This works for all insert mode exits as I would expect vim to do.

If you've remapped esc at all to change behavior, remove those mappings from your config or specify `evil_normal_mode` in them.